### PR TITLE
Update collection.clj

### DIFF
--- a/src/clarango/collection.clj
+++ b/src/clarango/collection.clj
@@ -4,12 +4,22 @@
         [clarango.utilities.uri-utility :only [build-resource-uri build-document-uri-from-two-parts]]))
 
 (defn get-all-documents
-  "Returns a vector with the URIs of all documents in the collection.
+  "Returns a vector with the URIs (or keys or ids) of all documents in the collection.
 
   Can be called without arguments. In that case the default collection from the default database will be used.
-  Optionally you can pass a collection name as first and a database name as second argument."
+  Optionally you can pass a collection name as first and a database name as second argument. 
+  You can also include a map as a last argument containing the 'type' parameter that specifies whether vector of URIs, 
+  keys or ids should be returned.
+  
+  E.g. this method call:
+      (get-all-documents \"collection-name\" {:type \"id\"}) 
+  will return list of document ids."
   [& args]
-  (http/get-uri [:body "documents"] (apply build-resource-uri "document/?collection=" nil (remove-options-map args))))
+  (http/get-uri [:body "documents"] 
+                (clojure.string/join
+                  [(apply build-resource-uri "document/?collection=" nil (remove-options-map args))
+                   "&type=" 
+                   (or (:type (last args)) "path")])))
 
 (defn get-delayed-collection
   "Returns a map with all documents in the collection as delays in the form {:document-key (delay (document/get document-name)) ...}.


### PR DESCRIPTION
Adding support of **type** attribute into `get-all-documents` function. This enables a user to retrieve list of ids or keys of all documents, not just their URI paths. As per ArangoDB REST API documentation:
`type: The type of the result. The following values are allowed:`
   `id: returns an array of document ids (_id attributes)`
   `key: returns an array of document keys (_key attributes)`
   `path: returns an array of document URI paths. This is the default.`
So far only URI path (the default option) was supported.

This is a quick fix, leverages current "ignoring" of any map added as an argument. Long term it would be nice to have some more generic higher-order function handling for such request parameters - i.e. to incorporate the additional GET parameters like this one into the current URI construction (`build-resource-uri` function).